### PR TITLE
Make applications field optional in extended_service.py

### DIFF
--- a/instana_client/models/extended_service.py
+++ b/instana_client/models/extended_service.py
@@ -28,7 +28,7 @@ class ExtendedService(BaseModel):
     """
     List of services in the topology.
     """ # noqa: E501
-    applications: List[StrictStr]
+    applications: Optional[List[StrictStr]] = Field(default_factory=list)
     entity_type: Optional[StrictStr] = Field(default=None, description="Since, this is a Service, it will be of type `SERVICE`.", alias="entityType")
     id: StrictStr = Field(description="Unique ID of the Service. Eg: `3feb3dcd206c166ef2b41c707e0cd38d7cd325aa`.")
     label: StrictStr = Field(description="Name of the Service. Eg: `payment`.")


### PR DESCRIPTION
When calling `ApplicationTopologyApi.get_services_map` the returning `services` in `response_data` is missing entirely the `application` field.

```
{
  "connections": [
    {
      "from": "8bfb4e1aa590eab8f08f837b97acf5803a5737ed",
      "to": "f17e7efb3b9b2d62bfec6b07905759fb81e99797",
      "calls": 2179,
      "latency": 1.6103717301514455,
      "errorRate": 0
    }
  ],
  "services": [
    {
      "id": "f17e7efb3b9b2d62bfec6b07905759fb81e99797",
      "label": "robot-shop",
      "types": [
        "MESSAGING"
      ],
      "technologies": [
        "kubernetesService",
        "rabbitMq"
      ],
      "snapshotIds": [],
      "entityType": "SERVICE"
    }
  ]
}
```
    
After that, the validation in `extended_service.py` fails and throws an exception.
