### PR TITLE
INSTA-48963 : MCP: REST API based access to Events related endpoints

### DIFF
--- a/instana_client/models/event_result.py
+++ b/instana_client/models/event_result.py
@@ -50,7 +50,7 @@ class EventResult(BaseModel):
     metrics: Optional[List[Dict[str, Any]]] = Field(default=None, description="List of metrics associated with the Event.")
     probable_cause: Optional[Dict[str, Any]] = Field(default=None, description="Metadata of the probable root cause for this event. Only present in case of specific \"Incident\" type events.", alias="probableCause")
     problem: Optional[StrictStr] = Field(default=None, description="Main problem title of the Event.")
-    recentEvents: Optional[List[Dict[str, Any]]] = Field(default=None, description="List of related recent events. Only present in case of \"Incident\" type events.", alias="recentEvents")
+    recent_events: Optional[List[Dict[str, Any]]] = Field(default=None, description="List of related recent events. Only present in case of \"Incident\" type events.", alias="recentEvents")
     severity: Optional[StrictInt] = Field(default=None, description="The severity of the Event when triggered.")
     snapshot_id: Optional[StrictStr] = Field(default=None, description="The snapshot ID of the affected entity of this event.", alias="snapshotId")
     start: Optional[StrictInt] = Field(default=None, description="A Unix timestamp representing the start time of the Event.")


### PR DESCRIPTION
Flattened nested types: metrics and probable_cause now use Dict[str, Any] instead of Dict[str, Dict[str, Any]] to better reflect actual API responses and allow more flexible data structures.

For reference - Associated Jira cards: 
[INSTA-48963](https://jsw.ibm.com/browse/INSTA-48963)
[INSTA-48965](https://jsw.ibm.com/browse/INSTA-48965)